### PR TITLE
Fix large pieces creation

### DIFF
--- a/Sources/TextBufferKit/PieceTreeBase.swift
+++ b/Sources/TextBufferKit/PieceTreeBase.swift
@@ -1136,7 +1136,7 @@ public class PieceTreeBase {
     
     func createNewPieces(_ _text: [UInt8]) -> [Piece]
     {
-        var text = _text[0..<_text.count]
+        var text = Array(_text[0..<_text.count])
         
         if text.count > AverageBufferSize {
             // the content is large, operations like subString, charCode becomes slow
@@ -1150,10 +1150,10 @@ public class PieceTreeBase {
                 if lastChar == 13 || (lastChar >= 0xD800 && lastChar <= 0xDBFF) {
                     // last character is \r or a high surrogate => keep it back
                     splitText = Array (text [0..<(AverageBufferSize - 1)])
-                    text = text [(AverageBufferSize - 1)...]
+                    text = Array(text [(AverageBufferSize - 1)...])
                 } else {
                     splitText = Array (text [0..<AverageBufferSize])
-                    text = text[AverageBufferSize...]
+                    text = Array(text[AverageBufferSize...])
                 }
 
                 let lineStarts = LineStarts.createLineStartsArray(Array (splitText))


### PR DESCRIPTION
For large pieces, indices for slices were not right. Just used array for easier calculations here.

Reproduce:

Load a content this file (2mb) 
[sample-2mb-text-file.txt](https://github.com/migueldeicaza/TextBufferKit/files/6413581/sample-2mb-text-file.txt)

        let pieceTree = PieceTreeTextBufferBuilder().finish(normalizeEol: true) .create(.LF)
        pieceTree.insert(offset: 0, value: Array(string.utf8))